### PR TITLE
Add Composer info and make class extensible

### DIFF
--- a/Annotations.php
+++ b/Annotations.php
@@ -27,13 +27,13 @@ class Annotations
      * Static array to store already parsed annotations
      * @var array
      */
-    private static $annotationCache;
+    protected static $annotationCache;
 
     /**
      * Indicates that annotations should has strict behavior, 'false' by default
      * @var boolean
      */
-    private $strict = false;
+    protected $strict = false;
 
     /**
      * Stores the default namespace for Objects instance, usually used on methods like getMethodAnnotationsObjects()
@@ -161,7 +161,7 @@ class Annotations
      * @param  string $docblock
      * @return array parsed annotations params
      */
-    private static function parseAnnotations($docblock)
+    protected static function parseAnnotations($docblock)
     {
         $annotations = array();
 
@@ -195,7 +195,7 @@ class Annotations
      * @param  string $content arguments string
      * @return array           annotated arguments
      */
-    private static function parseArgs($content)
+    protected static function parseArgs($content)
     {
         $data  = array();
         $len   = strlen($content);
@@ -333,7 +333,7 @@ class Annotations
      * @param  boolean $trim indicate if the value passed should be trimmed after to try cast
      * @return mixed         returns the value converted to original type if was possible
      */
-    private static function castValue($val, $trim = false)
+    protected static function castValue($val, $trim = false)
     {
         if (is_array($val)) {
             foreach ($val as $key => $value) {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "eriknyk/Annotations",
+    "type": "library",
+    "description": "Simple and Lightweight PHP Class & Methods Annotations Reader",
+    "keywords": [],
+    "homepage": "https://github.com/eriknyk/Annotations",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Erik Amaru Ortiz",
+            "email": "aortiz.erik@gmail.com"
+        }
+    ],
+    "autoload": {
+        "psr-0": { "Alchemy\\Component\\Annotations\\": "" }
+    },
+    "target-dir": "Alchemy/Component/Annotations"
+}


### PR DESCRIPTION
Great library. However, it is currently not easily usable with Composer. I added a simple composer.json file, so we can at least  define it as a package without putting the link to the ZIP download. But, if you can add it to Packagist, all the better.

Secondly, the class uses private instead of protected, making it a class that is not easily extensible. I need to change some of its behavior in a sub-class, for example, which is currently not possible. So, I changed all private properties and methods to protected.
